### PR TITLE
New netip/IP Type

### DIFF
--- a/cmd/gommunityid.go
+++ b/cmd/gommunityid.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net"
+	"net/netip"
 	"os"
 	"strconv"
 
@@ -61,13 +61,13 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		srcip := net.ParseIP(tupleCmd.Args()[1])
-		if srcip == nil {
-			log.Fatalf("%s is not a valid IP address", tupleCmd.Args()[1])
+		srcip, err := netip.ParseAddr(tupleCmd.Args()[1])
+		if err != nil {
+			log.Fatalf("%s is not a valid IP address: %s", tupleCmd.Args()[1], err)
 		}
-		dstip := net.ParseIP(tupleCmd.Args()[2])
-		if dstip == nil {
-			log.Fatalf("%s is not a valid IP address", tupleCmd.Args()[2])
+		dstip, err := netip.ParseAddr(tupleCmd.Args()[2])
+		if err != nil {
+			log.Fatalf("%s is not a valid IP address: %s", tupleCmd.Args()[2], err)
 		}
 		srcport, err := strconv.ParseUint(tupleCmd.Args()[3], 10, 16)
 		if err != nil {

--- a/communityid_v1.go
+++ b/communityid_v1.go
@@ -40,15 +40,15 @@ func (cid CommunityIDv1) CalcBase64(ft FlowTuple) string {
 func (cid CommunityIDv1) Hash(ft FlowTuple) hash.Hash {
 	h := sha1.New()
 	binary.Write(h, binary.BigEndian, cid.Seed)
-	if ft.Srcip.To4() != nil {
-		binary.Write(h, binary.BigEndian, ft.Srcip.To4())
-	} else if ft.Srcip.To16() != nil {
-		binary.Write(h, binary.BigEndian, ft.Srcip.To16())
+	if ft.Srcip.Is4() {
+		binary.Write(h, binary.BigEndian, ft.Srcip.As4())
+	} else if ft.Srcip.Is6() {
+		binary.Write(h, binary.BigEndian, ft.Srcip.As16())
 	}
-	if ft.Dstip.To4() != nil {
-		binary.Write(h, binary.BigEndian, ft.Dstip.To4())
-	} else if ft.Dstip.To16() != nil {
-		binary.Write(h, binary.BigEndian, ft.Dstip.To16())
+	if ft.Dstip.Is4() {
+		binary.Write(h, binary.BigEndian, ft.Dstip.As4())
+	} else if ft.Dstip.Is6() {
+		binary.Write(h, binary.BigEndian, ft.Dstip.As16())
 	}
 	h.Write([]byte{ft.Proto, 0})
 	binary.Write(h, binary.BigEndian, ft.Srcport)

--- a/communityid_v1_test.go
+++ b/communityid_v1_test.go
@@ -201,7 +201,7 @@ func TestCommunityIDv1UDP(t *testing.T) {
 		MakeFlowTupleUDP)
 }
 
-func BenchmarkIsOrdered(b *testing.B) {
+func BenchmarkCalc(b *testing.B) {
 	tpl := FlowTuple{
 		Dstip:   netip.MustParseAddr("1.2.3.4"),
 		Srcip:   netip.MustParseAddr("4.5.6.7"),

--- a/communityid_v1_test.go
+++ b/communityid_v1_test.go
@@ -2,15 +2,15 @@ package gommunityid
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 type testSet struct {
-	Srcip       net.IP
-	Dstip       net.IP
+	Srcip       netip.Addr
+	Dstip       netip.Addr
 	Srcport     uint16
 	Dstport     uint16
 	Base64Seed0 string
@@ -18,7 +18,7 @@ type testSet struct {
 	Base64Seed1 string
 }
 
-type makeFunc func(net.IP, net.IP, uint16, uint16) FlowTuple
+type makeFunc func(netip.Addr, netip.Addr, uint16, uint16) FlowTuple
 
 func verifyTuples(t *testing.T, ts []testSet, mf makeFunc) {
 	cid0 := CommunityIDv1{
@@ -39,8 +39,8 @@ func verifyTuples(t *testing.T, ts []testSet, mf makeFunc) {
 func TestCommunityIDv1ICMP(t *testing.T) {
 	verifyTuples(t, []testSet{
 		{
-			Srcip:       net.IPv4(192, 168, 0, 89),
-			Dstip:       net.IPv4(192, 168, 0, 1),
+			Srcip:       netip.MustParseAddr("192.168.0.89"),
+			Dstip:       netip.MustParseAddr("192.168.0.1"),
 			Srcport:     8,
 			Dstport:     0,
 			Base64Seed0: "1:X0snYXpgwiv9TZtqg64sgzUn6Dk=",
@@ -48,8 +48,8 @@ func TestCommunityIDv1ICMP(t *testing.T) {
 			Base64Seed1: "1:03g6IloqVBdcZlPyX8r0hgoE7kA=",
 		},
 		{
-			Srcip:       net.IPv4(192, 168, 0, 1),
-			Dstip:       net.IPv4(192, 168, 0, 89),
+			Srcip:       netip.MustParseAddr("192.168.0.1"),
+			Dstip:       netip.MustParseAddr("192.168.0.89"),
 			Srcport:     0,
 			Dstport:     8,
 			Base64Seed0: "1:X0snYXpgwiv9TZtqg64sgzUn6Dk=",
@@ -57,8 +57,8 @@ func TestCommunityIDv1ICMP(t *testing.T) {
 			Base64Seed1: "1:03g6IloqVBdcZlPyX8r0hgoE7kA=",
 		},
 		{
-			Srcip:       net.IPv4(192, 168, 0, 89),
-			Dstip:       net.IPv4(192, 168, 0, 1),
+			Srcip:       netip.MustParseAddr("192.168.0.89"),
+			Dstip:       netip.MustParseAddr("192.168.0.1"),
 			Srcport:     20,
 			Dstport:     0,
 			Base64Seed0: "1:3o2RFccXzUgjl7zDpqmY7yJi8rI=",
@@ -66,8 +66,8 @@ func TestCommunityIDv1ICMP(t *testing.T) {
 			Base64Seed1: "1:lCXHHxavE1Vq3oX9NH5ladQg02o=",
 		},
 		{
-			Srcip:       net.IPv4(192, 168, 0, 89),
-			Dstip:       net.IPv4(192, 168, 0, 1),
+			Srcip:       netip.MustParseAddr("192.168.0.89"),
+			Dstip:       netip.MustParseAddr("192.168.0.1"),
 			Srcport:     20,
 			Dstport:     1,
 			Base64Seed0: "1:tz/fHIDUHs19NkixVVoOZywde+I=",
@@ -75,8 +75,8 @@ func TestCommunityIDv1ICMP(t *testing.T) {
 			Base64Seed1: "1:Ie3wmFyxiEyikbsbcO03d2nh+PM=",
 		},
 		{
-			Srcip:       net.IPv4(192, 168, 0, 1),
-			Dstip:       net.IPv4(192, 168, 0, 89),
+			Srcip:       netip.MustParseAddr("192.168.0.1"),
+			Dstip:       netip.MustParseAddr("192.168.0.89"),
 			Srcport:     0,
 			Dstport:     20,
 			Base64Seed0: "1:X0snYXpgwiv9TZtqg64sgzUn6Dk=",
@@ -90,8 +90,8 @@ func TestCommunityIDv1ICMP(t *testing.T) {
 func TestCommunityIDv1ICMP6(t *testing.T) {
 	verifyTuples(t, []testSet{
 		{
-			Srcip:       net.ParseIP("fe80::200:86ff:fe05:80da"),
-			Dstip:       net.ParseIP("fe80::260:97ff:fe07:69ea"),
+			Srcip:       netip.MustParseAddr("fe80::200:86ff:fe05:80da"),
+			Dstip:       netip.MustParseAddr("fe80::260:97ff:fe07:69ea"),
 			Srcport:     135,
 			Dstport:     0,
 			Base64Seed0: "1:dGHyGvjMfljg6Bppwm3bg0LO8TY=",
@@ -99,8 +99,8 @@ func TestCommunityIDv1ICMP6(t *testing.T) {
 			Base64Seed1: "1:kHa1FhMYIT6Ym2Vm2AOtoOARDzY=",
 		},
 		{
-			Srcip:       net.ParseIP("fe80::260:97ff:fe07:69ea"),
-			Dstip:       net.ParseIP("fe80::200:86ff:fe05:80da"),
+			Srcip:       netip.MustParseAddr("fe80::260:97ff:fe07:69ea"),
+			Dstip:       netip.MustParseAddr("fe80::200:86ff:fe05:80da"),
 			Srcport:     136,
 			Dstport:     0,
 			Base64Seed0: "1:dGHyGvjMfljg6Bppwm3bg0LO8TY=",
@@ -108,8 +108,8 @@ func TestCommunityIDv1ICMP6(t *testing.T) {
 			Base64Seed1: "1:kHa1FhMYIT6Ym2Vm2AOtoOARDzY=",
 		},
 		{
-			Srcip:       net.ParseIP("3ffe:507:0:1:260:97ff:fe07:69ea"),
-			Dstip:       net.ParseIP("3ffe:507:0:1:200:86ff:fe05:80da"),
+			Srcip:       netip.MustParseAddr("3ffe:507:0:1:260:97ff:fe07:69ea"),
+			Dstip:       netip.MustParseAddr("3ffe:507:0:1:200:86ff:fe05:80da"),
 			Srcport:     3,
 			Dstport:     0,
 			Base64Seed0: "1:NdobDX8PQNJbAyfkWxhtL2Pqp5w=",
@@ -117,8 +117,8 @@ func TestCommunityIDv1ICMP6(t *testing.T) {
 			Base64Seed1: "1:OlOWx9psIbBFi7lOCw/4MhlKR9M=",
 		},
 		{
-			Srcip:       net.ParseIP("3ffe:507:0:1:200:86ff:fe05:80da"),
-			Dstip:       net.ParseIP("3ffe:507:0:1:260:97ff:fe07:69ea"),
+			Srcip:       netip.MustParseAddr("3ffe:507:0:1:200:86ff:fe05:80da"),
+			Dstip:       netip.MustParseAddr("3ffe:507:0:1:260:97ff:fe07:69ea"),
 			Srcport:     3,
 			Dstport:     0,
 			Base64Seed0: "1:/OGBt9BN1ofenrmSPWYicpij2Vc=",
@@ -132,8 +132,8 @@ func TestCommunityIDv1ICMP6(t *testing.T) {
 func TestCommunityIDv1SCTP(t *testing.T) {
 	verifyTuples(t, []testSet{
 		{
-			Srcip:       net.IPv4(192, 168, 170, 8),
-			Dstip:       net.IPv4(192, 168, 170, 56),
+			Srcip:       netip.MustParseAddr("192.168.170.8"),
+			Dstip:       netip.MustParseAddr("192.168.170.56"),
 			Srcport:     7,
 			Dstport:     80,
 			Base64Seed0: "1:jQgCxbku+pNGw8WPbEc/TS/uTpQ=",
@@ -141,8 +141,8 @@ func TestCommunityIDv1SCTP(t *testing.T) {
 			Base64Seed1: "1:Y1/0jQg6e+I3ZwZZ9LP65DNbTXU=",
 		},
 		{
-			Srcip:       net.IPv4(192, 168, 170, 56),
-			Dstip:       net.IPv4(192, 168, 170, 8),
+			Srcip:       netip.MustParseAddr("192.168.170.56"),
+			Dstip:       netip.MustParseAddr("192.168.170.8"),
 			Srcport:     80,
 			Dstport:     7,
 			Base64Seed0: "1:jQgCxbku+pNGw8WPbEc/TS/uTpQ=",
@@ -156,8 +156,8 @@ func TestCommunityIDv1SCTP(t *testing.T) {
 func TestCommunityIDv1TCP(t *testing.T) {
 	verifyTuples(t, []testSet{
 		{
-			Srcip:       net.IPv4(128, 232, 110, 120),
-			Dstip:       net.IPv4(66, 35, 250, 204),
+			Srcip:       netip.MustParseAddr("128.232.110.120"),
+			Dstip:       netip.MustParseAddr("66.35.250.204"),
 			Srcport:     34855,
 			Dstport:     80,
 			Base64Seed0: "1:LQU9qZlK+B5F3KDmev6m5PMibrg=",
@@ -165,8 +165,8 @@ func TestCommunityIDv1TCP(t *testing.T) {
 			Base64Seed1: "1:3V71V58M3Ksw/yuFALMcW0LAHvc=",
 		},
 		{
-			Srcip:       net.IPv4(66, 35, 250, 204),
-			Dstip:       net.IPv4(128, 232, 110, 120),
+			Srcip:       netip.MustParseAddr("66.35.250.204"),
+			Dstip:       netip.MustParseAddr("128.232.110.120"),
 			Srcport:     80,
 			Dstport:     34855,
 			Base64Seed0: "1:LQU9qZlK+B5F3KDmev6m5PMibrg=",
@@ -180,8 +180,8 @@ func TestCommunityIDv1TCP(t *testing.T) {
 func TestCommunityIDv1UDP(t *testing.T) {
 	verifyTuples(t, []testSet{
 		{
-			Srcip:       net.IPv4(192, 168, 1, 52),
-			Dstip:       net.IPv4(8, 8, 8, 8),
+			Srcip:       netip.MustParseAddr("192.168.1.52"),
+			Dstip:       netip.MustParseAddr("8.8.8.8"),
 			Srcport:     54585,
 			Dstport:     53,
 			Base64Seed0: "1:d/FP5EW3wiY1vCndhwleRRKHowQ=",
@@ -189,8 +189,8 @@ func TestCommunityIDv1UDP(t *testing.T) {
 			Base64Seed1: "1:Q9We8WO3piVF8yEQBNJF4uiSVrI=",
 		},
 		{
-			Srcip:       net.IPv4(8, 8, 8, 8),
-			Dstip:       net.IPv4(192, 168, 1, 52),
+			Srcip:       netip.MustParseAddr("8.8.8.8"),
+			Dstip:       netip.MustParseAddr("192.168.1.52"),
 			Srcport:     53,
 			Dstport:     54585,
 			Base64Seed0: "1:d/FP5EW3wiY1vCndhwleRRKHowQ=",

--- a/communityid_v1_test.go
+++ b/communityid_v1_test.go
@@ -200,3 +200,24 @@ func TestCommunityIDv1UDP(t *testing.T) {
 	},
 		MakeFlowTupleUDP)
 }
+
+func BenchmarkIsOrdered(b *testing.B) {
+	tpl := FlowTuple{
+		Dstip:   netip.MustParseAddr("1.2.3.4"),
+		Srcip:   netip.MustParseAddr("4.5.6.7"),
+		Srcport: 2,
+		Dstport: 1,
+		Proto:   6,
+	}
+
+	cid := CommunityIDv1{
+		Seed: 0,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		cid.Calc(tpl)
+	}
+
+}

--- a/flowtuple.go
+++ b/flowtuple.go
@@ -1,14 +1,13 @@
 package gommunityid
 
 import (
-	"bytes"
-	"net"
+	"net/netip"
 )
 
 // FlowTuple is a collection of all values required for ID calculation.
 type FlowTuple struct {
-	Srcip    net.IP
-	Dstip    net.IP
+	Srcip    netip.Addr
+	Dstip    netip.Addr
 	Srcport  uint16
 	Dstport  uint16
 	Proto    uint8
@@ -18,7 +17,7 @@ type FlowTuple struct {
 // MakeFlowTuple returns a FlowTuple for the given set of communication
 // details: protocol, IPs (source, destination) and ports (source,
 // destination).
-func MakeFlowTuple(srcip, dstip net.IP, srcport, dstport uint16, proto uint8) FlowTuple {
+func MakeFlowTuple(srcip, dstip netip.Addr, srcport, dstport uint16, proto uint8) FlowTuple {
 	var isOneWay bool
 	if proto == ProtoICMP {
 		srcport, dstport, isOneWay = GetICMPv4PortEquivalents(uint8(srcport), uint8(dstport))
@@ -37,32 +36,32 @@ func MakeFlowTuple(srcip, dstip net.IP, srcport, dstport uint16, proto uint8) Fl
 }
 
 // MakeFlowTupleTCP returns a FlowTuple with the TCP protocol preconfigured.
-func MakeFlowTupleTCP(srcip, dstip net.IP, srcport, dstport uint16) FlowTuple {
+func MakeFlowTupleTCP(srcip, dstip netip.Addr, srcport, dstport uint16) FlowTuple {
 	return MakeFlowTuple(srcip, dstip, srcport, dstport, ProtoTCP)
 }
 
 // MakeFlowTupleUDP returns a FlowTuple with the UDP protocol preconfigured.
-func MakeFlowTupleUDP(srcip, dstip net.IP, srcport, dstport uint16) FlowTuple {
+func MakeFlowTupleUDP(srcip, dstip netip.Addr, srcport, dstport uint16) FlowTuple {
 	return MakeFlowTuple(srcip, dstip, srcport, dstport, ProtoUDP)
 }
 
 // MakeFlowTupleSCTP returns a FlowTuple with the SCTP protocol preconfigured.
-func MakeFlowTupleSCTP(srcip, dstip net.IP, srcport, dstport uint16) FlowTuple {
+func MakeFlowTupleSCTP(srcip, dstip netip.Addr, srcport, dstport uint16) FlowTuple {
 	return MakeFlowTuple(srcip, dstip, srcport, dstport, ProtoSCTP)
 }
 
 // MakeFlowTupleICMP returns a FlowTuple with the ICMPv4 protocol preconfigured.
-func MakeFlowTupleICMP(srcip, dstip net.IP, srcport, dstport uint16) FlowTuple {
+func MakeFlowTupleICMP(srcip, dstip netip.Addr, srcport, dstport uint16) FlowTuple {
 	return MakeFlowTuple(srcip, dstip, srcport, dstport, ProtoICMP)
 }
 
 // MakeFlowTupleICMP6 returns a FlowTuple with the ICMPv6 protocol preconfigured.
-func MakeFlowTupleICMP6(srcip, dstip net.IP, srcport, dstport uint16) FlowTuple {
+func MakeFlowTupleICMP6(srcip, dstip netip.Addr, srcport, dstport uint16) FlowTuple {
 	return MakeFlowTuple(srcip, dstip, srcport, dstport, ProtoICMP6)
 }
 
-func flowTupleOrdered(addr1, addr2 []byte, port1, port2 uint16) bool {
-	return bytes.Compare(addr1, addr2) == -1 || (bytes.Equal(addr1, addr2) && port1 < port2)
+func flowTupleOrdered(addr1, addr2 netip.Addr, port1, port2 uint16) bool {
+	return addr1.Compare(addr2) == -1 || (addr1 == addr2 && port1 < port2)
 }
 
 // IsOrdered returns true if the flow tuple direction is ordered.

--- a/flowtuple_test.go
+++ b/flowtuple_test.go
@@ -1,7 +1,7 @@
 package gommunityid
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,16 +9,16 @@ import (
 
 func TestFlowTupleOrder(t *testing.T) {
 	tpl := FlowTuple{
-		Srcip:   net.IPv4(1, 2, 3, 4),
-		Dstip:   net.IPv4(4, 5, 6, 7),
+		Srcip:   netip.MustParseAddr("1.2.3.4"),
+		Dstip:   netip.MustParseAddr("4.5.6.7"),
 		Srcport: 1,
 		Dstport: 2,
 	}
 	assert.True(t, tpl.IsOrdered())
 
 	tpl2 := FlowTuple{
-		Dstip:   net.IPv4(1, 2, 3, 4),
-		Srcip:   net.IPv4(4, 5, 6, 7),
+		Dstip:   netip.MustParseAddr("1.2.3.4"),
+		Srcip:   netip.MustParseAddr("4.5.6.7"),
 		Srcport: 2,
 		Dstport: 1,
 	}

--- a/pcap_flowtuple_source.go
+++ b/pcap_flowtuple_source.go
@@ -1,7 +1,7 @@
 package gommunityid
 
 import (
-	"net"
+	"net/netip"
 	"os"
 
 	"github.com/google/gopacket"
@@ -35,16 +35,18 @@ func PcapFlowTupleSource(file string) (<-chan PcapFlowTuple, error) {
 		for packet := range packetSource.Packets() {
 			var ft FlowTuple
 
-			var src, dst net.IP
+			var src, dst netip.Addr
 			ip4Layer := packet.Layer(layers.LayerTypeIPv4)
 			if ip4Layer != nil {
 				ip, _ := ip4Layer.(*layers.IPv4)
-				src, dst = ip.SrcIP, ip.DstIP
+				src, _ = netip.AddrFromSlice(ip.SrcIP)
+				dst, _ = netip.AddrFromSlice(ip.DstIP)
 			} else {
 				ip6Layer := packet.Layer(layers.LayerTypeIPv6)
 				if ip6Layer != nil {
 					ip, _ := ip6Layer.(*layers.IPv6)
-					src, dst = ip.SrcIP, ip.DstIP
+					src, _ = netip.AddrFromSlice(ip.SrcIP)
+					dst, _ = netip.AddrFromSlice(ip.DstIP)
 				} else {
 					// no IP layer found
 					continue


### PR DESCRIPTION
Hello,

Firstly, thanks for such a great package! 😄 

I was wondering if you would be open to having his package use the new `net/netip` package instead of `net`. The benefits of this new package are detailed in a multiple blog posts such as [here](https://tailscale.com/blog/netaddr-new-ip-type-for-go/) and [here](https://djosephsen.github.io/posts/ipnet/). The main purpose of moving to this would be to allow for easier integration with code using the new IP type (which is hopefully become more common place). 

I added a benchmark to verify that there wouldn't been a performance regression, of which there hasn't, see bellow for the results:

**net.IP**
```
BenchmarkCalc-10    	 3808719	       310.0 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3869238	       311.8 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3862005	       310.9 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3858036	       310.4 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3852278	       310.3 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3869430	       314.4 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3723308	       317.3 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3792819	       310.8 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3823431	       314.5 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 3883435	       312.9 ns/op	     152 B/op	       7 allocs/op
```
**net/netip**
```
BenchmarkCalc-10    	 3871975	       297.8 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4048564	       297.1 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4002990	       297.4 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4026421	       297.1 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4036520	       298.1 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4036999	       297.5 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4048945	       297.4 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4030039	       297.2 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4028685	       297.2 ns/op	     152 B/op	       7 allocs/op
BenchmarkCalc-10    	 4016073	       297.4 ns/op	     152 B/op	       7 allocs/op
```

